### PR TITLE
Ignore bad Skeletal Meshes

### DIFF
--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SkeletalMeshGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SkeletalMeshGenerator.cpp
@@ -88,9 +88,12 @@ void USkeletalMeshGenerator::SetupFbxImportSettings(UFbxImportUI* ImportUI) cons
 
 	if (!IsGeneratingPublicProject()) {
 		const int32 SkeletonObjectIndex = GetAssetData()->GetObjectField(TEXT("AssetObjectData"))->GetIntegerField(TEXT("Skeleton"));
-		USkeleton* Skeleton = CastChecked<USkeleton>(GetObjectSerializer()->DeserializeObject(SkeletonObjectIndex));
-		
-		ImportUI->Skeleton = Skeleton;
+		USkeleton* Skeleton = Cast<USkeleton>(GetObjectSerializer()->DeserializeObject(SkeletonObjectIndex));
+
+		if (Skeleton)
+		{
+			ImportUI->Skeleton = Skeleton;
+		}
 	} else {
 		ImportUI->Skeleton = FPublicProjectStubHelper::DefaultSkeletalMeshSkeleton.GetObject();
 	}


### PR DESCRIPTION
Updated to replace CastChecked with regular Cast and null check. This prevents the generator from throwing a hard exception on bad Skeletal Meshes and instead it just moves on.