### PR TITLE
List SML as a plugin dep to silence VS warning

### DIFF
--- a/AssetDumper/AssetDumper.uplugin
+++ b/AssetDumper/AssetDumper.uplugin
@@ -25,7 +25,8 @@
 	"Plugins": [
 		{
 			"Name": "SML",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 	]
 }

--- a/AssetDumper/AssetDumper.uplugin
+++ b/AssetDumper/AssetDumper.uplugin
@@ -21,5 +21,11 @@
 			"Type": "Runtime",
 			"LoadingPhase": "PostDefault"
 		}
+	],
+	"Plugins": [
+		{
+			"Name": "SML",
+			"Enabled": true
+		},
 	]
 }


### PR DESCRIPTION
`UnrealBuildTool: Warning: Plugin ‘AssetDumper’ does not list plugin ‘SML’ as a dependency, but module ‘AssetDumper’ depends on ‘SML’`

https://forums.unrealengine.com/t/unrealbuildtool-dependancy-warning/404128